### PR TITLE
Feature/thumbs file collections

### DIFF
--- a/netlify-cms@2/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
+++ b/netlify-cms@2/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js
@@ -95,6 +95,7 @@ function EntryCard({
   collectionLabel,
   viewStyle = VIEW_STYLE_LIST,
   getAsset,
+  inferedFields,
 }) {
   if (viewStyle === VIEW_STYLE_LIST) {
     return (
@@ -115,7 +116,8 @@ function EntryCard({
             {collectionLabel ? <CollectionLabel>{collectionLabel}</CollectionLabel> : null}
             <CardHeading>{summary}</CardHeading>
           </CardBody>
-          {image ? <CardImage src={getAsset(image, imageField).toString()} /> : null}
+          {inferedFields?.filesArray?.some(file => file[summary]) ? <CardImage src={getAsset(inferedFields?.filesArray.filter(file => file[summary])[0][summary]).toString()} />
+            : image && <CardImage src={getAsset(image, imageField).toString()} />}
         </GridCardLink>
       </GridCard>
     );

--- a/netlify-cms@2/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
+++ b/netlify-cms@2/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import { Waypoint } from 'react-waypoint';
 import { Map } from 'immutable';
 
-import { selectFields, selectInferedField } from '../../../reducers/collections';
+import { selectFields, selectInferedField, selectEntryThumbnail } from '../../../reducers/collections';
 import EntryCard from './EntryCard';
 
 const CardsGrid = styled.ul`
@@ -43,10 +43,14 @@ export default class EntryListing extends React.Component {
     const descriptionField = selectInferedField(collection, 'description');
     const imageField = selectInferedField(collection, 'image');
     const fields = selectFields(collection);
+    const files = selectEntryThumbnail(collection)
+
     const inferedFields = [titleField, descriptionField, imageField];
     const remainingFields =
       fields && fields.filter(f => inferedFields.indexOf(f.get('name')) === -1);
-    return { titleField, descriptionField, imageField, remainingFields };
+    let thumbs = {}
+    const filesArray = files ? files.toArray().map((a) => Object.assign({ ...thumbs }, { [a.get('label')]: a.get('thumbnail') })) : null
+    return { titleField, descriptionField, imageField, remainingFields, filesArray };
   };
 
   renderCardsForSingleCollection = () => {
@@ -65,6 +69,7 @@ export default class EntryListing extends React.Component {
       const collectionLabel = !isSingleCollectionInList && collection.get('label');
       const inferedFields = this.inferFields(collection);
       const entryCardProps = { collection, entry, inferedFields, collectionLabel };
+
       return <EntryCard {...entryCardProps} key={idx} />;
     });
   };

--- a/netlify-cms@2/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
+++ b/netlify-cms@2/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
@@ -69,7 +69,6 @@ export default class EntryListing extends React.Component {
       const collectionLabel = !isSingleCollectionInList && collection.get('label');
       const inferedFields = this.inferFields(collection);
       const entryCardProps = { collection, entry, inferedFields, collectionLabel };
-
       return <EntryCard {...entryCardProps} key={idx} />;
     });
   };

--- a/netlify-cms@2/packages/netlify-cms-core/src/reducers/collections.ts
+++ b/netlify-cms@2/packages/netlify-cms-core/src/reducers/collections.ts
@@ -204,6 +204,11 @@ export function selectTemplateName(collection: Collection, slug: string) {
   return selectors[collection.get('type')].templateName(collection, slug);
 }
 
+export function selectEntryThumbnail(collection: Collection) {
+  if (collection.has('files')) return collection.get('files')
+  return null;
+}
+
 export function getFieldsNames(fields: EntryField[], prefix = '') {
   let names = fields.map(f => `${prefix}${f.get('name')}`);
 

--- a/netlify-cms@2/packages/netlify-cms-core/src/types/redux.ts
+++ b/netlify-cms@2/packages/netlify-cms-core/src/types/redux.ts
@@ -576,6 +576,7 @@ export type CollectionFile = StaticallyTypedRecord<{
   public_folder?: string;
   preview_path?: string;
   preview_path_date_field?: string;
+  thumbnail?: string
 }>;
 
 export type CollectionFiles = List<CollectionFile>;
@@ -629,6 +630,7 @@ type CollectionObject = {
   nested?: Nested;
   meta?: Meta;
   i18n: i18n;
+  thumbnail?: string
 };
 
 export type Collection = StaticallyTypedRecord<CollectionObject>;


### PR DESCRIPTION
Issue: [https://github.com/ecomplus/storefront-cms/issues/4]
Adicionar thumb aos files de uma collection... ex:

- name: 'example'
    label: 'Example'
    files:
      - name: 'example'
        label: 'Example Test' 
        file: '_data/example.json'
        description: 'General Example Test'
        thumbnail: 'thumbnails/nameImage.jpg'
        fields:
            {...}

Caso não possuir files na collection, funcionará como antes, pegando o widget image de dentro do field, caso possuir ele.